### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Enable version updates for Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "go"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "github-actions"
+


### PR DESCRIPTION
Adds a simple dependabot config for this repo.

Similar to: 
- https://github.com/sebrandon1/yaml-to-readme/pull/2
- https://github.com/rh-ecosystem-edge/eco-goinfra/pull/240
- https://github.com/redhat-best-practices-for-k8s/pgt2acm/pull/1
- https://github.com/sebrandon1/go-dci/pull/2
- https://github.com/sebrandon1/go-quay/pull/4
- https://github.com/redhat-best-practices-for-k8s/certsuite-overview/pull/8
- https://github.com/openshift/cert-manager-operator/pull/256
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/954
- https://github.com/redhat-best-practices-for-k8s/telco-bot/pull/3