### PR TITLE
Add fix to action.yml

### DIFF
--- a/.github/workflows/test-fix-mode.yml
+++ b/.github/workflows/test-fix-mode.yml
@@ -1,0 +1,245 @@
+name: Test Fix Mode
+
+on:
+  pull_request:
+  push:
+    branches:
+      - add_fix
+  workflow_dispatch:
+
+jobs:
+  test-fix-mode:
+    name: Test Automatic URL Fixing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Create test file with outdated URLs
+        run: |
+          mkdir -p test-fix-output
+          cat > test-fix-output/test-doc.md << 'EOF'
+          # Test Documentation with Outdated URLs
+          
+          This file contains intentionally outdated OCP documentation URLs for testing.
+          
+          ## Documentation Links
+          
+          - [4.15 Networking](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html-single/networking/index)
+          - [4.16 Storage](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html-single/storage/index)
+          - [4.17 Disconnected Environments](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/disconnected_environments/index#mirroring-image-set-full)
+          
+          Inline reference: https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html-single/security_and_compliance/index
+          
+          Another link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html-single/authentication_and_authorization/index
+          EOF
+
+      - name: Show original file content
+        run: |
+          echo "=========================================="
+          echo "📄 BEFORE: Original file content"
+          echo "=========================================="
+          cat test-fix-output/test-doc.md
+          echo ""
+          echo "=========================================="
+
+      - name: Run checker in check-only mode first
+        uses: ./
+        id: check-only
+        continue-on-error: true
+        with:
+          paths: 'test-fix-output/test-doc.md'
+          fail-on-outdated: false
+          verbose: true
+
+      - name: Display check-only results
+        run: |
+          echo "Check-only mode results:"
+          echo "  Total URLs: ${{ steps.check-only.outputs.total-count }}"
+          echo "  Up-to-date: ${{ steps.check-only.outputs.uptodate-count }}"
+          echo "  Outdated: ${{ steps.check-only.outputs.outdated-count }}"
+          echo "  Is Outdated: ${{ steps.check-only.outputs.is-outdated }}"
+
+      - name: Run checker with fix mode enabled
+        uses: ./
+        id: fix-mode
+        with:
+          paths: 'test-fix-output/test-doc.md'
+          fix: true
+
+      - name: Show updated file content
+        run: |
+          echo ""
+          echo "=========================================="
+          echo "📄 AFTER: Updated file content"
+          echo "=========================================="
+          cat test-fix-output/test-doc.md
+          echo ""
+          echo "=========================================="
+
+      - name: Show git diff
+        run: |
+          echo ""
+          echo "=========================================="
+          echo "🔍 Git Diff - Changes Made"
+          echo "=========================================="
+          git diff --no-index --word-diff=color /dev/null test-fix-output/test-doc.md || true
+          echo ""
+          echo "Detailed diff:"
+          git diff --no-index test-fix-output/test-doc.md || true
+
+      - name: Verify fixes were applied
+        run: |
+          echo ""
+          echo "=========================================="
+          echo "✅ Verification"
+          echo "=========================================="
+          
+          # Check if old version URLs are gone (check in URL paths, not link text)
+          if grep -q "openshift_container_platform/4\.15/" test-fix-output/test-doc.md; then
+            echo "❌ ERROR: Found 4.15 URLs that should have been updated"
+            grep "openshift_container_platform/4\.15/" test-fix-output/test-doc.md
+            exit 1
+          fi
+          
+          if grep -q "openshift_container_platform/4\.16/" test-fix-output/test-doc.md; then
+            echo "❌ ERROR: Found 4.16 URLs that should have been updated"
+            grep "openshift_container_platform/4\.16/" test-fix-output/test-doc.md
+            exit 1
+          fi
+          
+          if grep -q "openshift_container_platform/4\.17/" test-fix-output/test-doc.md; then
+            echo "❌ ERROR: Found 4.17 URLs that should have been updated"
+            grep "openshift_container_platform/4\.17/" test-fix-output/test-doc.md
+            exit 1
+          fi
+          
+          # Check if file contains updated URLs with 4.19
+          if ! grep -q "openshift_container_platform/4\.19/" test-fix-output/test-doc.md; then
+            echo "❌ ERROR: No updated 4.19 URLs found"
+            exit 1
+          fi
+          
+          echo "✅ All outdated URLs successfully updated!"
+          echo "✅ No old version numbers (4.15, 4.16, 4.17) remain in URLs"
+          echo "✅ File contains updated 4.19 documentation URLs"
+
+  test-fix-mode-multiple-files:
+    name: Test Fix Mode - Multiple Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Create multiple test files
+        run: |
+          mkdir -p test-fix-multi
+          
+          cat > test-fix-multi/doc1.md << 'EOF'
+          # Document 1
+          Links: https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html-single/networking/index
+          EOF
+          
+          cat > test-fix-multi/doc2.md << 'EOF'
+          # Document 2
+          Links: https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html-single/storage/index
+          EOF
+          
+          cat > test-fix-multi/doc3.md << 'EOF'
+          # Document 3
+          Links: https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/authentication_and_authorization/index
+          EOF
+
+      - name: Show original files
+        run: |
+          echo "Original files:"
+          echo "--- doc1.md ---"
+          cat test-fix-multi/doc1.md
+          echo "--- doc2.md ---"
+          cat test-fix-multi/doc2.md
+          echo "--- doc3.md ---"
+          cat test-fix-multi/doc3.md
+
+      - name: Run fix on entire directory
+        uses: ./
+        with:
+          paths: 'test-fix-multi/'
+          fix: true
+          verbose: true
+
+      - name: Show updated files
+        run: |
+          echo ""
+          echo "Updated files:"
+          echo "--- doc1.md ---"
+          cat test-fix-multi/doc1.md
+          echo "--- doc2.md ---"
+          cat test-fix-multi/doc2.md
+          echo "--- doc3.md ---"
+          cat test-fix-multi/doc3.md
+
+      - name: Verify all files were updated
+        run: |
+          echo "Verifying updates..."
+          
+          # Check for old version numbers in URL paths specifically
+          if grep -r "openshift_container_platform/4\.15/" test-fix-multi/; then
+            echo "❌ ERROR: Found 4.15 URLs that should have been updated"
+            exit 1
+          fi
+          
+          if grep -r "openshift_container_platform/4\.16/" test-fix-multi/; then
+            echo "❌ ERROR: Found 4.16 URLs that should have been updated"
+            exit 1
+          fi
+          
+          if grep -r "openshift_container_platform/4\.17/" test-fix-multi/; then
+            echo "❌ ERROR: Found 4.17 URLs that should have been updated"
+            exit 1
+          fi
+          
+          # Verify updated URLs are present
+          if ! grep -r "openshift_container_platform/4\.19/" test-fix-multi/; then
+            echo "❌ ERROR: No updated 4.19 URLs found"
+            exit 1
+          fi
+          
+          echo "✅ All files in directory successfully updated!"
+
+  test-fix-mode-no-outdated:
+    name: Test Fix Mode - No Outdated URLs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Create test file with current URLs
+        run: |
+          mkdir -p test-fix-current
+          cat > test-fix-current/current.md << 'EOF'
+          # Already Up-to-date
+          This file has current documentation links.
+          Link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/networking/index
+          EOF
+
+      - name: Run fix mode on up-to-date file
+        uses: ./
+        id: fix-current
+        with:
+          paths: 'test-fix-current/current.md'
+          fix: true
+
+      - name: Verify no changes were made
+        run: |
+          echo "File content after fix mode:"
+          cat test-fix-current/current.md
+          
+          # Verify 4.19 is still there in the URL path (wasn't changed unnecessarily)
+          if ! grep -q "openshift_container_platform/4\.19/" test-fix-current/current.md; then
+            echo "❌ ERROR: Current URLs were incorrectly modified or removed"
+            exit 1
+          fi
+          
+          echo "✅ Correctly left up-to-date URLs unchanged!"
+
+

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Check OCP Documentation URL
-        uses: sebrandon1/ocp-doc-checker@main
+        uses: sebrandon1/ocp-doc-checker@v1
         with:
           url: 'https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/disconnected_environments/index#mirroring-image-set-full'
           fail-on-outdated: true
@@ -124,17 +124,31 @@ jobs:
 
 ```yaml
 - name: Scan documentation files
-  uses: sebrandon1/ocp-doc-checker@main
+  uses: sebrandon1/ocp-doc-checker@v1
   with:
     paths: 'docs/ README.md CONTRIBUTING.md'
     fail-on-outdated: true
 ```
 
+### Automatically Fix Outdated URLs
+
+```yaml
+- name: Fix outdated documentation URLs
+  uses: sebrandon1/ocp-doc-checker@v1
+  with:
+    paths: 'docs/ README.md'
+    fix: true
+```
+
+In conjunction with a PR creation action, this can create a powerful tool to automatically fix your outdated URLs.
+
+This will automatically update any outdated OCP documentation URLs in the specified files to their latest versions. When `fix` is enabled, the action won't fail even if outdated URLs were found (since they've been fixed).
+
 ### Non-Blocking Check
 
 ```yaml
 - name: Check documentation (warning only)
-  uses: sebrandon1/ocp-doc-checker@main
+  uses: sebrandon1/ocp-doc-checker@v1
   with:
     paths: 'docs/'
     fail-on-outdated: false
@@ -144,7 +158,7 @@ jobs:
 
 ```yaml
 - name: Check with all versions
-  uses: sebrandon1/ocp-doc-checker@main
+  uses: sebrandon1/ocp-doc-checker@v1
   with:
     url: 'https://docs.redhat.com/...'
     all-available: true
@@ -160,8 +174,9 @@ jobs:
 | `fail-on-outdated` | Fail the action if outdated URLs are found | No | `true` |
 | `all-available` | Show all available newer versions | No | `false` |
 | `verbose` | Enable verbose output | No | `false` |
+| `fix` | Automatically fix outdated URLs in files (only works with `paths`) | No | `false` |
 
-**Note:** Either `url` or `paths` must be specified, but not both.
+**Note:** Either `url` or `paths` must be specified, but not both. The `fix` option can only be used with `paths`.
 
 ### Action Outputs
 
@@ -187,7 +202,7 @@ jobs:
 ```yaml
 - name: Check documentation
   id: doc-check
-  uses: sebrandon1/ocp-doc-checker@main
+  uses: sebrandon1/ocp-doc-checker@v1
   with:
     url: 'https://docs.redhat.com/...'
     fail-on-outdated: false

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Enable verbose output'
     required: false
     default: 'false'
+  fix:
+    description: 'Automatically fix outdated URLs in files (only works with paths, not single URL)'
+    required: false
+    default: 'false'
 
 outputs:
   is-outdated:
@@ -79,6 +83,12 @@ runs:
           exit 1
         fi
         
+        # Validate fix flag usage
+        if [ "${{ inputs.fix }}" = "true" ] && [ -n "${{ inputs.url }}" ]; then
+          echo "::error::The 'fix' option can only be used with 'paths', not with a single 'url'."
+          exit 1
+        fi
+        
         # Single URL mode
         if [ -n "${{ inputs.url }}" ]; then
           OUTPUT=$(/tmp/ocp-doc-checker -url "${{ inputs.url }}" $FLAGS -json)
@@ -122,6 +132,62 @@ runs:
         fi
         
         # Batch mode - scan paths for URLs
+        
+        # If fix mode is enabled, use the binary's built-in fix functionality
+        if [ "${{ inputs.fix }}" = "true" ]; then
+          echo "=========================================="
+          echo "🔧 FIX MODE ENABLED"
+          echo "=========================================="
+          echo "Automatically updating outdated URLs..."
+          echo ""
+          echo "### 🔧 Automatically Fixing Outdated URLs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          for path in ${{ inputs.paths }}; do
+            echo "----------------------------------------"
+            echo "Processing path: $path"
+            echo "----------------------------------------"
+            
+            if [ -f "$path" ]; then
+              echo "Type: File"
+              echo "Running: /tmp/ocp-doc-checker -dir $path -fix"
+              echo ""
+              /tmp/ocp-doc-checker -dir "$path" -fix 2>&1 || {
+                echo "::warning::Fix operation failed for $path with exit code $?"
+              }
+              echo ""
+            elif [ -d "$path" ]; then
+              echo "Type: Directory"
+              echo "Running: /tmp/ocp-doc-checker -dir $path -fix"
+              echo ""
+              /tmp/ocp-doc-checker -dir "$path" -fix 2>&1 || {
+                echo "::warning::Fix operation failed for $path with exit code $?"
+              }
+              echo ""
+            else
+              echo "::warning::Path not found: $path"
+            fi
+          done
+          
+          echo "=========================================="
+          echo "✅ FIX MODE COMPLETED"
+          echo "=========================================="
+          echo ""
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **Fixes completed!**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "All outdated documentation URLs have been updated to their latest versions." >> $GITHUB_STEP_SUMMARY
+          
+          # Set outputs for fix mode (we don't have detailed counts in fix mode)
+          echo "is-outdated=false" >> $GITHUB_OUTPUT
+          echo "outdated-count=0" >> $GITHUB_OUTPUT
+          echo "uptodate-count=0" >> $GITHUB_OUTPUT
+          echo "total-count=0" >> $GITHUB_OUTPUT
+          
+          exit 0
+        fi
+        
+        # Check-only mode: scan and report
         echo "### 📋 OCP Documentation URL Check" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         


### PR DESCRIPTION
This pull request adds a new "auto-fix" feature to the `ocp-doc-checker` GitHub Action, allowing it to automatically update outdated documentation URLs in files. It also updates the documentation to reflect this new functionality and switches all usage examples to reference the stable `v1` release of the action.

**Auto-fix functionality:**

* Added a new `fix` input to `action.yml` that enables automatic fixing of outdated URLs in files specified by `paths`. This is validated to ensure it is not used with single `url` mode. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R28-R31) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R86-R91)
* Implemented logic in the action to apply fixes to files or directories when `fix` is enabled, and updated the summary output to indicate successful fixes. The action will not fail due to outdated URLs if they have been fixed.

**Documentation updates:**

* Updated all example usages in `README.md` to use `sebrandon1/ocp-doc-checker@v1` instead of `@main` for stability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-R117) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R151) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-R161) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L190-R205)
* Added documentation and usage examples for the new `fix` option, including a dedicated section on automatically fixing outdated URLs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R151) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R177-R179)
* Clarified in the documentation that the `fix` option can only be used with `paths` and not with a single `url`.