### PR TITLE
Default the 'paths' action variable

### DIFF
--- a/.github/workflows/test-fix-mode.yml
+++ b/.github/workflows/test-fix-mode.yml
@@ -206,6 +206,39 @@ jobs:
           
           echo "✅ All files in directory successfully updated!"
 
+  test-fix-mode-default-path:
+    name: Test Fix Mode - Default Path
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Create test file with outdated URL in current directory
+        run: |
+          cat > test-default.md << 'EOF'
+          # Test Default Path Behavior
+          Link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html-single/networking/index
+          EOF
+          cat test-default.md
+
+      - name: Run fix mode without specifying paths
+        uses: ./
+        with:
+          fix: true
+
+      - name: Verify file was updated
+        run: |
+          echo "Checking if file was updated..."
+          cat test-default.md
+          
+          # Verify the URL was updated
+          if grep -q "openshift_container_platform/4\.19/" test-default.md; then
+            echo "✅ File was updated to 4.19!"
+          else
+            echo "❌ ERROR: File was not updated"
+            exit 1
+          fi
+
   test-fix-mode-no-outdated:
     name: Test Fix Mode - No Outdated URLs
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ In conjunction with a PR creation action, this can create a powerful tool to aut
 
 This will automatically update any outdated OCP documentation URLs in the specified files to their latest versions. When `fix` is enabled, the action won't fail even if outdated URLs were found (since they've been fixed).
 
+### Fix All URLs in Repository
+
+```yaml
+- name: Fix all outdated URLs in repository
+  uses: sebrandon1/ocp-doc-checker@v1
+  with:
+    fix: true
+```
+
+If you don't specify `paths`, the action defaults to scanning the current directory (`.`), which will recursively scan all supported files in your repository.
+
 ### Non-Blocking Check
 
 ```yaml
@@ -170,13 +181,13 @@ This will automatically update any outdated OCP documentation URLs in the specif
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `url` | Single OCP documentation URL to check | No | - |
-| `paths` | Space-separated list of files/directories to scan | No | - |
+| `paths` | Space-separated list of files/directories to scan | No | `.` (current dir) |
 | `fail-on-outdated` | Fail the action if outdated URLs are found | No | `true` |
 | `all-available` | Show all available newer versions | No | `false` |
 | `verbose` | Enable verbose output | No | `false` |
 | `fix` | Automatically fix outdated URLs in files (only works with `paths`) | No | `false` |
 
-**Note:** Either `url` or `paths` must be specified, but not both. The `fix` option can only be used with `paths`.
+**Note:** `url` and `paths` are mutually exclusive. If neither is specified, `paths` defaults to the current directory (`.`). The `fix` option can only be used with `paths` mode.
 
 ### Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'OCP documentation URL to check (mutually exclusive with paths)'
     required: false
   paths:
-    description: 'Space-separated list of files or directories to scan for OCP URLs (mutually exclusive with url)'
+    description: 'Space-separated list of files or directories to scan for OCP URLs (mutually exclusive with url). Defaults to current directory if not specified.'
     required: false
   fail-on-outdated:
     description: 'Fail the action if documentation is outdated'
@@ -72,14 +72,9 @@ runs:
           FLAGS="$FLAGS -all-available"
         fi
         
-        # Check if both url and paths are provided or neither
+        # Check if both url and paths are provided
         if [ -n "${{ inputs.url }}" ] && [ -n "${{ inputs.paths }}" ]; then
           echo "::error::Cannot specify both 'url' and 'paths'. Use one or the other."
-          exit 1
-        fi
-        
-        if [ -z "${{ inputs.url }}" ] && [ -z "${{ inputs.paths }}" ]; then
-          echo "::error::Must specify either 'url' or 'paths'."
           exit 1
         fi
         
@@ -87,6 +82,13 @@ runs:
         if [ "${{ inputs.fix }}" = "true" ] && [ -n "${{ inputs.url }}" ]; then
           echo "::error::The 'fix' option can only be used with 'paths', not with a single 'url'."
           exit 1
+        fi
+        
+        # Default to current directory if neither url nor paths specified
+        SCAN_PATHS="${{ inputs.paths }}"
+        if [ -z "${{ inputs.url }}" ] && [ -z "${{ inputs.paths }}" ]; then
+          echo "No paths specified, defaulting to current directory (.)"
+          SCAN_PATHS="."
         fi
         
         # Single URL mode
@@ -143,7 +145,7 @@ runs:
           echo "### 🔧 Automatically Fixing Outdated URLs" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
-          for path in ${{ inputs.paths }}; do
+          for path in $SCAN_PATHS; do
             echo "----------------------------------------"
             echo "Processing path: $path"
             echo "----------------------------------------"
@@ -193,7 +195,7 @@ runs:
         
         # Find all files to scan
         FILES=""
-        for path in ${{ inputs.paths }}; do
+        for path in $SCAN_PATHS; do
           if [ -f "$path" ]; then
             FILES="$FILES $path"
           elif [ -d "$path" ]; then
@@ -209,7 +211,7 @@ runs:
         fi
         
         echo "Scanning files for OCP documentation URLs..."
-        echo "**Scanned paths:** ${{ inputs.paths }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Scanned paths:** $SCAN_PATHS" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
         # Extract unique OCP documentation URLs


### PR DESCRIPTION
This pull request updates the default behavior of the action to scan the current directory when no `paths` or `url` is specified, making it easier to use for bulk updates. It also clarifies documentation and input descriptions, and adds a new test to validate the default path behavior.

**Default Path Handling and Input Logic:**
- The action now defaults to scanning the current directory (`.`) recursively if neither `paths` nor `url` is specified, improving usability for repository-wide checks. This is implemented by introducing a `SCAN_PATHS` variable and updating all relevant references from `inputs.paths` to `SCAN_PATHS`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L75-R93) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L146-R148) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L196-R198) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L212-R214)

**Documentation Updates:**
- The `README.md` is updated to document the new default path behavior, including an example of fixing all outdated URLs in a repository and clarifying the mutual exclusivity and defaults for `url` and `paths`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R147-R157) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L173-R190)
- The `action.yml` input description for `paths` is updated to indicate that it defaults to the current directory if not specified.

**Testing Improvements:**
- Adds a new workflow job (`test-fix-mode-default-path`) to `.github/workflows/test-fix-mode.yml` that verifies the action correctly updates files in the current directory when no `paths` are specified.