### PR TITLE
Add ability to run via image

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,66 @@
+name: Publish Container Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and Publish Container Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "major_version=${VERSION%%.*}" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev" >> $GITHUB_OUTPUT
+            echo "major_version=dev" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate Docker tags
+        id: tags
+        run: |
+          REPO="quay.io/bapalm/ocp-doc-checker"
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ steps.version.outputs.version }}"
+            MAJOR="${{ steps.version.outputs.major_version }}"
+            TAGS="${REPO}:${VERSION},${REPO}:${MAJOR},${REPO}:latest"
+          else
+            TAGS="${REPO}:dev"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: echo "Image published successfully! 🎉"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Multi-stage build for ocp-doc-checker
+# Stage 1: Build the Go binary
+FROM golang:1.25-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o ocp-doc-checker .
+
+# Stage 2: Create minimal runtime image
+FROM alpine:latest
+
+# Install ca-certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates
+
+# Create a non-root user
+RUN adduser -D -u 1000 checker
+
+# Set working directory
+WORKDIR /workspace
+
+# Copy binary from builder
+COPY --from=builder /build/ocp-doc-checker /usr/local/bin/ocp-doc-checker
+
+# Make sure binary is executable
+RUN chmod +x /usr/local/bin/ocp-doc-checker
+
+# Switch to non-root user
+USER checker
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/ocp-doc-checker"]
+
+# Default command (shows help)
+CMD ["--help"]
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A tool to check if OpenShift Container Platform (OCP) documentation URLs are out
 [![Test Fix Mode](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/test-fix-mode.yml/badge.svg)](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/test-fix-mode.yml)
 [![Lint Markdown](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/lint-markdown.yml)
 [![Release Binaries](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/release-binaries.yaml/badge.svg)](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/release-binaries.yaml)
+[![Publish Container Image](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/publish-container.yml/badge.svg)](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/publish-container.yml)
 [![Update Major Tag](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/update-major-tag.yml/badge.svg)](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/update-major-tag.yml)
 [![Example](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/example.yml/badge.svg)](https://github.com/sebrandon1/ocp-doc-checker/actions/workflows/example.yml)
 
@@ -20,6 +21,23 @@ A tool to check if OpenShift Container Platform (OCP) documentation URLs are out
 - 🔍 Batch processing with detailed reports
 
 ## Installation
+
+### Container Image
+
+The easiest way to use the tool without installing anything:
+
+```bash
+# Using Docker
+docker run --rm -v $(pwd):/workspace quay.io/bapalm/ocp-doc-checker:latest -dir /workspace
+
+# Using Podman
+podman run --rm -v $(pwd):/workspace:Z quay.io/bapalm/ocp-doc-checker:latest -dir /workspace
+```
+
+Images are available at `quay.io/bapalm/ocp-doc-checker` with the following tags:
+- `latest` - Latest stable release
+- `v1` - Latest v1.x release
+- `v1.x.x` - Specific version (e.g., `v1.0.0`)
 
 ### Binary
 
@@ -101,6 +119,47 @@ This will:
 ```bash
 ./ocp-doc-checker -dir ./docs -fix -verbose
 ```
+
+### Container Usage Examples
+
+All CLI examples above can be run using the container image by mounting your workspace:
+
+#### Check a single URL
+
+```bash
+docker run --rm quay.io/bapalm/ocp-doc-checker:latest \
+  -url "https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/disconnected_environments/index#mirroring-image-set-full"
+```
+
+#### Scan current directory
+
+```bash
+docker run --rm -v $(pwd):/workspace quay.io/bapalm/ocp-doc-checker:latest \
+  -dir /workspace
+```
+
+#### Scan specific files with JSON output
+
+```bash
+docker run --rm -v $(pwd):/workspace quay.io/bapalm/ocp-doc-checker:latest \
+  -dir /workspace/docs -json
+```
+
+#### Fix outdated URLs automatically
+
+```bash
+docker run --rm -v $(pwd):/workspace quay.io/bapalm/ocp-doc-checker:latest \
+  -dir /workspace/docs -fix
+```
+
+#### Using Podman (with SELinux)
+
+```bash
+podman run --rm -v $(pwd):/workspace:Z quay.io/bapalm/ocp-doc-checker:latest \
+  -dir /workspace -fix -verbose
+```
+
+**Note:** When using the container, paths must be relative to `/workspace` since that's where your local directory is mounted.
 
 ### Exit Codes
 


### PR DESCRIPTION
This pull request adds support for building and publishing a container image for the project, making it easier for users to run the tool without installing dependencies. It introduces a multi-stage Docker build, sets up a GitHub Actions workflow to automate container publishing on release, and updates the documentation to reflect these changes and provide usage examples.

**Containerization and Publishing:**
* Added a multi-stage `Dockerfile` to build a minimal container image for `ocp-doc-checker`, including a non-root user and support for running on multiple architectures.
* Introduced a new GitHub Actions workflow (`.github/workflows/publish-container.yml`) to automatically build and publish the container image to Quay.io on release or manual dispatch.

**Documentation Updates:**
* Updated `README.md` to add a badge for the new container publishing workflow and document how to use the container image, including available tags. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R41)
* Added detailed container usage examples to the `README.md`, showing how to run the tool via Docker or Podman for various scenarios.