### PR TITLE
Add make path for building image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-unit test-integration test-ci clean install fmt lint help
+.PHONY: build test test-unit test-integration test-ci clean install fmt lint build-image help
 
 BINARY_NAME=ocp-doc-checker
 VERSION?=dev
@@ -6,6 +6,11 @@ COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 LDFLAGS=-ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
+
+IMAGE_NAME?=ocp-doc-checker
+IMAGE_TAG?=$(VERSION)
+IMAGE_REGISTRY?=quay.io
+IMAGE_REPO?=$(IMAGE_REGISTRY)/$(IMAGE_NAME)
 
 all: test build
 
@@ -82,6 +87,12 @@ lint:
 		echo "golangci-lint not installed, skipping..."; \
 	fi
 
+build-image:
+	@echo "Building Docker image $(IMAGE_REPO):$(IMAGE_TAG)..."
+	docker build -t $(IMAGE_REPO):$(IMAGE_TAG) .
+	@echo "Tagging as $(IMAGE_REPO):latest..."
+	docker tag $(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):latest
+
 help:
 	@echo "Available targets:"
 	@echo "  build            - Build the binary"
@@ -93,5 +104,6 @@ help:
 	@echo "  install          - Install the binary to GOPATH/bin"
 	@echo "  fmt              - Format code"
 	@echo "  lint             - Run linters"
+	@echo "  build-image      - Build Docker image"
 	@echo "  help             - Show this help message"
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,18 @@ make install
 
 This installs the binary to `$GOPATH/bin`.
 
+### Build Container Image
+
+```bash
+make build-image
+```
+
+Builds the Docker image locally and tags it as `quay.io/ocp-doc-checker:dev` and `quay.io/ocp-doc-checker:latest`. You can customize the image name and tag:
+
+```bash
+make build-image IMAGE_REGISTRY=docker.io IMAGE_NAME=myorg/ocp-doc-checker VERSION=v1.0.0
+```
+
 ## How It Works
 
 1. **URL Parsing**: Extracts OCP version and document structure from Red Hat documentation URLs


### PR DESCRIPTION
For development testing only.

**Docker Image Build Support:**

* Added a new `build-image` target to the `Makefile` that builds a Docker image and tags it as both the specified version and `latest`. The image name, tag, and registry can be customized via variables. (`Makefile`) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R10-R14) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R90-R95)
* Updated the `.PHONY` and `help` sections in the `Makefile` to include the new `build-image` target. (`Makefile`) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R107)

**Documentation Updates:**

* Added instructions to the `README.md` for building the Docker image, including usage examples and variable customization. (`README.md`)