### PR TITLE
Matrix test-cli job to run test scripts in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,18 @@ jobs:
         run: go build -o ocp-doc-checker .
 
   test-cli:
-    name: Test CLI Functionality
+    name: Test CLI - ${{ matrix.test.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - { name: 'Outdated URL', script: 'test-outdated-url.sh', continue: true }
+          - { name: 'Current URL', script: 'test-current-url.sh', continue: false }
+          - { name: 'URL Accessibility', script: 'test-url-accessibility.sh', continue: false }
+          - { name: 'Invalid URL', script: 'test-invalid-url.sh', continue: false }
+          - { name: 'URL Replacement', script: 'test-url-replacement.sh', continue: false }
+          - { name: 'Anchor Validation', script: 'test-anchor-validation.sh', continue: false }
     steps:
       - name: Check Red Hat Status
         uses: palmsoftware/redhat-status@v0
@@ -48,34 +58,9 @@ jobs:
       - name: Build tool
         run: go build -o ocp-doc-checker .
 
-      - name: Test 1 - Outdated URL should fail
-        id: test1
-        continue-on-error: true
-        run: ./scripts/test-outdated-url.sh
-
-      - name: Test 2 - Current URL should pass
-        id: test2
-        run: ./scripts/test-current-url.sh
-
-      - name: Test 3 - Verify suggested URLs are accessible
-        id: test3
-        run: ./scripts/test-url-accessibility.sh
-
-      - name: Test 4 - Invalid URL should fail gracefully
-        id: test4
-        run: ./scripts/test-invalid-url.sh
-
-      - name: Test 5 - Specific version replacement
-        id: test5
-        run: ./scripts/test-url-replacement.sh
-
-      - name: Test 6 - Anchor validation with real docs
-        id: test6
-        run: ./scripts/test-anchor-validation.sh
-
-      - name: Test Summary
-        if: always()
-        run: ./scripts/generate-cli-test-summary.sh "${{ steps.test1.outcome }}" "${{ steps.test2.outcome }}" "${{ steps.test3.outcome }}" "${{ steps.test4.outcome }}" "${{ steps.test5.outcome }}" "${{ steps.test6.outcome }}"
+      - name: Run test - ${{ matrix.test.name }}
+        continue-on-error: ${{ matrix.test.continue }}
+        run: ./scripts/${{ matrix.test.script }}
 
   test-action:
     name: Test GitHub Action


### PR DESCRIPTION
## Summary

Convert the sequential test-cli job into a matrix strategy to run 6 test scripts in parallel.

## Changes

- test-cli job now uses matrix strategy with 6 independent test scripts
- Each test runs in its own job with its own runner
- Removed test summary step (individual test jobs provide clear pass/fail)
- Preserved continue-on-error for outdated URL test

## Expected Benefit

**Time savings: 15-30 seconds per run** - Six test scripts run in parallel instead of sequentially.

## Testing

The changes will be validated when CI runs on this PR.

## Related PRs

**Personal repos (sebrandon1):**
- bps-operator: https://github.com/sebrandon1/bps-operator/pull/115
- compliance-scripts: https://github.com/sebrandon1/compliance-scripts/pull/166
- go-dci: https://github.com/sebrandon1/go-dci/pull/143

**Organization repos (redhat-best-practices-for-k8s):**
- certsuite: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3748
- checks: https://github.com/redhat-best-practices-for-k8s/checks/pull/48
- checks-qe: https://github.com/redhat-best-practices-for-k8s/checks-qe/pull/39
- operator-results-spreadsheet: https://github.com/redhat-best-practices-for-k8s/operator-results-spreadsheet/pull/46